### PR TITLE
exclude non-library sources when uploading to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Determine whether characters have the XID_Start or XID_Continue p
 repository = "https://github.com/dtolnay/unicode-ident"
 documentation = "https://docs.rs/unicode-ident"
 readme = "README.md"
+exclude = ["/tests/", "/benches/", "/.github/", ".gitignore"]
 
 [dev-dependencies]
 criterion = { version = "0.3", default-features = false }


### PR DESCRIPTION
My main motivation is to remove the test data from `/tests/`, but I figured I'd clean up the other unneeded things while I was at it.

I care about the testdata because I'm trying to pull this crate into https://cs.opensource.google/fuchsia/fuchsia/+/main:third_party/rust_crates/vendor via `cargo vendor`, but it's not 100% clear what the license on the testdata is. Excluding it from being uploaded side-steps that problem entirely (and also makes everyone else's downloads slightly smaller)