### PR TITLE
Normalize ucd-generate version in generated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - id: ucd-generate
+        run: echo "::set-output name=version::$(grep 'ucd-generate [0-9]\+\.[0-9]\+\.[0-9]\+' generate/src/ucd.rs --only-matching)"
       - run: cargo install ucd-generate
       - run: curl -LO https://www.unicode.org/Public/zipped/latest/UCD.zip
       - run: unzip UCD.zip -d UCD
@@ -22,6 +24,7 @@ jobs:
       - run: ucd-generate property-bool UCD --include XID_Start,XID_Continue --fst-dir tests/fst
       - run: ucd-generate property-bool UCD --include XID_Start,XID_Continue --trie-set > tests/trie/trie.rs
       - run: cargo run --manifest-path generate/Cargo.toml
+      - run: sed --in-place 's/ucd-generate [0-9]\+\.[0-9]\+\.[0-9]\+/${{steps.ucd-generate.outputs.version}}/' generate/src/ucd.rs tests/trie/trie.rs
       - run: git diff --exit-code
 
   test:


### PR DESCRIPTION
Fixes the following failure in CI upon new releases of ucd-generate.

The job is only intended to fail on new releases of the unicode UCD database, not new releases of the ucd-generate tool.

```diff
$ Run git diff --exit-code

diff --git a/generate/src/ucd.rs b/generate/src/ucd.rs
index 1b57e17..56b7d29 100644
--- a/generate/src/ucd.rs
+++ b/generate/src/ucd.rs
@@ -4,7 +4,7 @@
 //
 // Unicode version: 14.0.0.
 //
-// ucd-generate 0.2.10 is available on crates.io.
+// ucd-generate 0.2.12 is available on crates.io.
 pub const BY_NAME: &'static [(&'static str, &'static [(u32, u32)])] = &[
   ("XID_Continue", XID_CONTINUE), ("XID_Start", XID_START),
diff --git a/tests/trie/trie.rs b/tests/trie/trie.rs
index 7f7a14f..6eabd0d 100644
--- a/tests/trie/trie.rs
+++ b/tests/trie/trie.rs
@@ -4,7 +4,7 @@
 //
 // Unicode version: 14.0.0.
 //
-// ucd-generate 0.2.10 is available on crates.io.
+// ucd-generate 0.2.12 is available on crates.io.
 pub const BY_NAME: &'static [(&'static str, &'static ::ucd_trie::TrieSet)] = &[
   ("XID_Continue", XID_CONTINUE), ("XID_Start", XID_START),
```