### PR TITLE
Explain what the unicode license means for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,3 +281,7 @@ generated files are involved.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
 be licensed as just described, without any additional terms or conditions.
+
+### What this means for users
+
+If you are using unicode-ident as a dependency of your project and your project is licensed under the Apache license, MIT license or other permissive licenses, then you can freely use unicode-ident in your project and do not need to include any additional copyright notices in your project.


### PR DESCRIPTION
Its not unicode-idents job to explain how licenses work but:
It is a very foundational crate, particularly so due to its use in syn.
So I imagine confusion over the unicode license like https://github.com/dtolnay/unicode-ident/issues/10 brought about by `cargo deny` is likely to happen again.

I discussed with a coworker who is knowledgeable about licenses about this issue and decided to add a notice to the readme about what I learnt in the hopes that it will clear up any confusion that others have.