### PR TITLE
Switch from set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - id: ucd-generate
-        run: echo "::set-output name=version::$(grep 'ucd-generate [0-9]\+\.[0-9]\+\.[0-9]\+' generate/src/ucd.rs --only-matching)"
+        run: echo "version=$(grep 'ucd-generate [0-9]\+\.[0-9]\+\.[0-9]\+' generate/src/ucd.rs --only-matching)" >> $GITHUB_OUTPUT
       - run: cargo install ucd-generate
       - run: curl -LO https://www.unicode.org/Public/zipped/latest/UCD.zip
       - run: unzip UCD.zip -d UCD


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.