### PR TITLE
Add doc comments to functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,7 @@ mod tables;
 
 use crate::tables::{ASCII_CONTINUE, ASCII_START, CHUNK, LEAF, TRIE_CONTINUE, TRIE_START};
 
+/// Returns [`true`] if `ch` satisfies the XID\_Start Unicode property.
 pub fn is_xid_start(ch: char) -> bool {
     if ch.is_ascii() {
         return ASCII_START.0[ch as usize];
@@ -259,6 +260,7 @@ pub fn is_xid_start(ch: char) -> bool {
     unsafe { LEAF.0.get_unchecked(offset) }.wrapping_shr(ch as u32 % 8) & 1 != 0
 }
 
+/// Returns [`true`] if `ch` satisfies the XID\_Continue Unicode property.
 pub fn is_xid_continue(ch: char) -> bool {
     if ch.is_ascii() {
         return ASCII_CONTINUE.0[ch as usize];


### PR DESCRIPTION
I think the purpose of `is_xid_continue` and `is_xid_start` functions is easy to understand from these names. However, I think it's better to have documentation for the public APIs than nothing, so I add this.