### PR TITLE
Re-word function doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,7 @@ mod tables;
 
 use crate::tables::{ASCII_CONTINUE, ASCII_START, CHUNK, LEAF, TRIE_CONTINUE, TRIE_START};
 
-/// Returns [`true`] if `ch` satisfies the XID\_Start Unicode property.
+/// Whether the character has the Unicode property XID\_Start.
 pub fn is_xid_start(ch: char) -> bool {
     if ch.is_ascii() {
         return ASCII_START.0[ch as usize];
@@ -260,7 +260,7 @@ pub fn is_xid_start(ch: char) -> bool {
     unsafe { LEAF.0.get_unchecked(offset) }.wrapping_shr(ch as u32 % 8) & 1 != 0
 }
 
-/// Returns [`true`] if `ch` satisfies the XID\_Continue Unicode property.
+/// Whether the character has the Unicode property XID\_Continue.
 pub fn is_xid_continue(ch: char) -> bool {
     if ch.is_ascii() {
         return ASCII_CONTINUE.0[ch as usize];


### PR DESCRIPTION
This better matches the framing in https://en.cppreference.com/w/cpp/language/identifiers, which talks about characters "with" a property instead of "satisfying" a property.