### PR TITLE
produce c api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "xid"
 harness = false
 
 [workspace]
-members = ["diagram", "generate"]
+members = ["c-api", "diagram", "generate"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "c-api"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[lib]
+name = "unicode_ident"
+path = "lib.rs"
+crate-type = ["staticlib"]
+
+[dependencies]
+unicode-ident.path = ".."

--- a/c-api/include/unicode_ident.h
+++ b/c-api/include/unicode_ident.h
@@ -1,0 +1,10 @@
+#ifndef UNICODE_IDENT_H
+#define UNICODE_IDENT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+bool is_xid_start(uint32_t ch);
+bool is_xid_continue(uint32_t ch);
+
+#endif

--- a/c-api/lib.rs
+++ b/c-api/lib.rs
@@ -1,0 +1,17 @@
+#[unsafe(no_mangle)]
+pub extern "C" fn is_xid_start(c: u32) -> bool {
+    if let Some(char) = char::from_u32(c) {
+        return unicode_ident::is_xid_start(char);
+    };
+
+    false
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn is_xid_continue(c: u32) -> bool {
+    if let Some(char) = char::from_u32(c) {
+        return unicode_ident::is_xid_continue(char);
+    };
+
+    false
+}


### PR DESCRIPTION
since this crate is among the fastest implementations of checking whether a char is xid start or continue, I figured it'd be convenient to export a C API for accessibility from other languages. 

this PR makes a `staticlib` buildable via `cargo build -p c-api`. the header is accessible via `c-api/include/unicode_ident.h`, matching the basename of the output object file eg `target/release/libunicode_ident.a`.