### PR TITLE
Update roaring dependency to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.31"
 criterion = { version = "0.6", default-features = false }
 fst = "0.4"
 rand = "0.9"
-roaring = "0.10"
+roaring = "0.11"
 ucd-trie = { version = "0.1", default-features = false }
 unicode-xid = "0.2.6"
 


### PR DESCRIPTION
Release notes: https://github.com/RoaringBitmap/roaring-rs/releases/tag/v0.11.0