### PR TITLE
store ascii start/continue bitmaps in u128 instead of slices of bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ different ratios of ASCII to non-ASCII codepoints in the input data.
 [`ucd-generate`]: https://github.com/BurntSushi/ucd-generate
 [`roaring`]: https://github.com/RoaringBitmap/roaring-rs
 
-| | static storage | 0% nonascii | 1% | 10% | 100% nonascii |
-|---|---|---|---|---|---|
-| **`unicode-ident`** | 10.5 K | 1.03 ns | 1.02 ns | 1.11 ns | 1.66 ns |
-| **`unicode-xid`** | 12.0 K | 2.57 ns | 2.74 ns | 3.20 ns | 9.35 ns |
-| **`ucd-trie`** | 10.4 K | 1.27 ns | 1.27 ns | 1.41 ns | 2.53 ns |
-| **`fst`** | 144 K | 49.3 ns | 49.1 ns | 47.1 ns | 27.9 ns |
-| **`roaring`** | 66.1 K | 4.10 ns | 4.05 ns | 4.02 ns | 5.12 ns |
+|                     | static storage | 0% nonascii | 1%       | 10%      | 100% nonascii |
+|---------------------|----------------|-------------|----------|----------|---------------|
+| **`unicode-ident`** | 10.3 K         | 0.58 ns     | 0.62 ns  | 0.98 ns  | 1.34 ns       |
+| **`unicode-xid`**   | 12.0 K         | 2.40 ns     | 2.46 ns  | 2.84 ns  | 5.66 ns       |
+| **`ucd-trie`**      | 10.4 K         | 0.92 ns     | 0.97 ns  | 1.42 ns  | 2.23 ns       |
+| **`fst`**           | 144 K          | 28.49 ns    | 28.33 ns | 27.64 ns | 15.70 ns      |
+| **`roaring`**       | 66.1 K         | 2.85 ns     | 2.85 ns  | 3.23 ns  | 4.55 ns       |
 
 Source code for the benchmark is provided in the *bench* directory of this repo
 and may be repeated by running `cargo criterion`.

--- a/generate/src/write.rs
+++ b/generate/src/write.rs
@@ -9,9 +9,6 @@ const HEAD: &str = "\
 // $ unzip UCD.zip -d UCD
 // $ cargo run --manifest-path generate/Cargo.toml
 
-const T: bool = true;
-const F: bool = false;
-
 #[repr(C, align(8))]
 pub(crate) struct Align8<T>(pub(crate) T);
 #[repr(C, align(64))]
@@ -27,36 +24,22 @@ pub fn output(
     let mut out = Output::new();
     writeln!(out, "{}", HEAD);
 
+    let ascii_start = (0u8..128)
+        .map(|c| (properties.is_xid_start(c as char) as u128) << c)
+        .sum::<u128>();
     writeln!(
         out,
-        "pub(crate) static ASCII_START: Align64<[bool; 128]> = Align64([",
+        "pub(crate) const ASCII_START: u128 = 0x{ascii_start:x};",
     );
-    for i in 0u8..4 {
-        write!(out, "   ");
-        for j in 0..32 {
-            let ch = (i * 32 + j) as char;
-            let is_xid_start = properties.is_xid_start(ch);
-            write!(out, " {},", if is_xid_start { 'T' } else { 'F' });
-        }
-        writeln!(out);
-    }
-    writeln!(out, "]);");
-    writeln!(out);
 
+    let ascii_continue = (0u8..128)
+        .map(|c| (properties.is_xid_continue(c as char) as u128) << c)
+        .sum::<u128>();
     writeln!(
         out,
-        "pub(crate) static ASCII_CONTINUE: Align64<[bool; 128]> = Align64([",
+        "pub(crate) const ASCII_CONTINUE: u128 = 0x{ascii_continue:x};",
     );
-    for i in 0u8..4 {
-        write!(out, "   ");
-        for j in 0..32 {
-            let ch = (i * 32 + j) as char;
-            let is_xid_continue = properties.is_xid_continue(ch);
-            write!(out, " {},", if is_xid_continue { 'T' } else { 'F' });
-        }
-        writeln!(out);
-    }
-    writeln!(out, "]);");
+
     writeln!(out);
 
     writeln!(out, "pub(crate) const CHUNK: usize = {};", CHUNK);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ use crate::tables::{ASCII_CONTINUE, ASCII_START, CHUNK, LEAF, TRIE_CONTINUE, TRI
 /// Whether the character has the Unicode property XID\_Start.
 pub fn is_xid_start(ch: char) -> bool {
     if ch.is_ascii() {
-        return ASCII_START.0[ch as usize];
+        return ASCII_START & (1 << ch as u128) != 0;
     }
     let chunk = *TRIE_START.0.get(ch as usize / 8 / CHUNK).unwrap_or(&0);
     let offset = chunk as usize * CHUNK / 2 + ch as usize / 8 % CHUNK;
@@ -263,7 +263,7 @@ pub fn is_xid_start(ch: char) -> bool {
 /// Whether the character has the Unicode property XID\_Continue.
 pub fn is_xid_continue(ch: char) -> bool {
     if ch.is_ascii() {
-        return ASCII_CONTINUE.0[ch as usize];
+        return ASCII_CONTINUE & (1 << ch as u128) != 0;
     }
     let chunk = *TRIE_CONTINUE.0.get(ch as usize / 8 / CHUNK).unwrap_or(&0);
     let offset = chunk as usize * CHUNK / 2 + ch as usize / 8 % CHUNK;

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -4,27 +4,13 @@
 // $ unzip UCD.zip -d UCD
 // $ cargo run --manifest-path generate/Cargo.toml
 
-const T: bool = true;
-const F: bool = false;
-
 #[repr(C, align(8))]
 pub(crate) struct Align8<T>(pub(crate) T);
 #[repr(C, align(64))]
 pub(crate) struct Align64<T>(pub(crate) T);
 
-pub(crate) static ASCII_START: Align64<[bool; 128]> = Align64([
-    F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
-    F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
-    F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, F, F, F, F, F,
-    F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, F, F, F, F, F,
-]);
-
-pub(crate) static ASCII_CONTINUE: Align64<[bool; 128]> = Align64([
-    F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
-    F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, T, T, T, T, T, T, T, T, T, T, F, F, F, F, F, F,
-    F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, F, F, F, F, T,
-    F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, F, F, F, F, F,
-]);
+pub(crate) const ASCII_START: u128 = 0x7fffffe07fffffe0000000000000000;
+pub(crate) const ASCII_CONTINUE: u128 = 0x7fffffe87fffffe03ff000000000000;
 
 pub(crate) const CHUNK: usize = 64;
 

--- a/tests/static_size.rs
+++ b/tests/static_size.rs
@@ -13,7 +13,7 @@ fn test_size() {
         + size_of_val(&tables::TRIE_START)
         + size_of_val(&tables::TRIE_CONTINUE)
         + size_of_val(&tables::LEAF);
-    assert_eq!(10472, size);
+    assert_eq!(10248, size);
 }
 
 #[test]


### PR DESCRIPTION
Hello,

Using slices of bools to store ASCII CONTINUE and START data results in using 2*128 bytes of memory since one entire byte is used to store each boolean.
Since ASCII chars are 128, bitmaps fit perfectly in u128 consts.

This change reduces execution time by 44% in 0%-nonascii case and by 32% in 10%-nonascii, according to the crates benches, and reduces the static storage by ~200 bytes.
Benchmarks were run on an Intel i5-12400 system.

Thanks